### PR TITLE
Add easy way to install and update plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# MediaBrowser.Plugins.VuPlus
-MediaBrowser Vu+ Plugin
-
-Plugin for MediaBrowser to allow it to view channels, browse epg, set and delete timers, play recordings etc.
+# Jellyfin Plugin Enigma2
+Plugin for Jellyfin to allow it to view channels, browse epg, set and delete timers, play recordings etc.
 
 Known Issues / Limitations
 --------------------------
@@ -17,10 +15,16 @@ Setup on Vu+ / Enigma2
 Ensure openWebIf is installed and running - go into settings and make a note of them so they can be entered on the MediaBrowser Vu+ config page.
  
  
-Setup on MediaBrowser server
+Setup on Jellyfin server
 ----------------------------
+Install the plugin:
+- Open Jellyfin and go to the Plugin section
+- Open the "Repositories" tab and add https://raw.githubusercontent.com/knackebrot/jellyfin-plugin-enigma2/jellyfin/manifest.json
+- Switch to the tab "Catalogue" and install the "Enigma2" plugin that you can find in the "Live-TV" section
+- Restart the Jellyfin server
 
-Install Vu+ plugin and restart MediaBrowser server.
+Configure the plugin:
+
 Go to config page for Vu+ and amend default contents as follows (at a minimum, the first 3 must be entered):
  
 Vu+ hostname or ip address:

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+[
+  {
+    "category": "Live TV",
+    "guid": "193f29f9-ea6c-4595-a6f6-55e79d7c590a",
+    "name": "Enigma2",
+    "description": "Live TV plugin for watching Enigma 2 channels and recordings",
+    "owner": "knackebrot",
+    "overview": "Enigma2",
+    "versions": [
+      {
+        "checksum": "97bbf70d09c6a0565d92c5735feed33d",
+        "changelog": "Jellyfin 10.8 compatibility",
+        "targetAbi": "10.8.0.0",
+        "sourceUrl": "https://github.com/knackebrot/jellyfin-plugin-enigma2/releases/download/5.0.0.0/Jellyfin.Plugin.Enigma2.zip",
+        "timestamp": "2022-06-29 00:00:00",
+        "version": "5.0.0.0"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Added a manifest.json which allows you to easily install the plugin on your jellyfin server.

When updating the plugin you can add a new release by filling out the "versions" block in the manifest.json like

>     {
>         "checksum": "97bbf70d09c6a0565d92c5735feed33d",
>         "changelog": "Jellyfin 10.8 compatibility",
>         "targetAbi": "10.8.0.0",
>         "sourceUrl": "https://github.com/knackebrot/jellyfin-plugin-enigma2/releases/download/5.0.0.0/Jellyfin.Plugin.Enigma2.zip",
>         "timestamp": "2022-06-29 00:00:00",
>         "version": "5.0.0.0"
>       }

Checksum is a MD5 hash of the zip file
